### PR TITLE
Improving bats tests

### DIFF
--- a/test/gentlemanjerry.bats
+++ b/test/gentlemanjerry.bats
@@ -2,10 +2,12 @@
 
 setup() {
   mkdir /tmp/certs
+  mkdir /tmp/logs
 }
 
 teardown() {
   rm -rf /tmp/certs
+  rm -rf /tmp/logs
 }
 
 @test "Gentleman Jerry reports an error if its certificate isn't in /tmp/certs" {
@@ -24,20 +26,34 @@ teardown() {
 
 @test "Gentleman Jerry should start up with a default configuration" {
   openssl req -x509 -batch -nodes -newkey rsa:2048 -keyout /tmp/certs/jerry.key -out /tmp/certs/jerry.crt
-  # Unfortunately, it takes a couple of seconds for logstash to start up. This
-  # timeout might need to be increased on slower machines.
-  run timeout 20s /bin/bash run-gentleman-jerry.sh
-  [ "$status" -eq 124 ]
+
+  # Unfortunately, it takes a while for logstash to start up. The tests below
+  # run the gentlemanjerry startup script in the background, then tail its
+  # output until we see a single line of output or 120 seconds have elapsed.
+  # When either condition is met, we kill the logstash process and test the
+  # output against what we expect.
+
+  /bin/bash run-gentleman-jerry.sh > /tmp/logs/jerry.logs &
+  run timeout 120 sh -c 'tail --pid=$$ -f /tmp/logs/jerry.logs | { sed "1 q" && kill $$ ;}'
+  pkill -f 'java.*logstash'
+  [ "$status" -eq 143 ]  # Command should have been terminated. We'd get 124 if it timed out.
   [[ "$output" =~ "Using milestone 1 input plugin 'lumberjack'" ]]
 }
 
 @test "Gentleman Jerry should start up with a syslog output configuration" {
   openssl req -x509 -batch -nodes -newkey rsa:2048 -keyout /tmp/certs/jerry.key -out /tmp/certs/jerry.crt
   export LOGSTASH_OUTPUT_CONFIG="syslog { facility => \"daemon\" host => \"127.0.0.1\" port => 514 severity => \"emergency\" }"
-  # Unfortunately, it takes a couple of seconds for logstash to start up. This
-  # timeout might need to be increased on slower machines.
-  run timeout 20s /bin/bash run-gentleman-jerry.sh
-  [ "$status" -eq 124 ]
+
+  # Unfortunately, it takes a while for logstash to start up. The tests below
+  # run the gentlemanjerry startup script in the background, then tail its
+  # output until we see two lines of output or 120 seconds have elapsed. When
+  # either condition is met, we kill the logstash process and test the output
+  # against what we expect.
+
+  /bin/bash run-gentleman-jerry.sh > /tmp/logs/jerry.logs &
+  run timeout 120 sh -c 'tail --pid=$$ -f /tmp/logs/jerry.logs | { sed "2 q" && kill $$ ;}'
+  pkill -f 'java.*logstash'
+  [ "$status" -eq 143 ]  # Command should have been terminated. We'd get 124 if it timed out.
   [[ "$output" =~ "Using milestone 1 input plugin 'lumberjack'" ]]
   [[ "$output" =~ "Using milestone 1 output plugin 'syslog'" ]]
 }


### PR DESCRIPTION
We're expecting some output from logstash once it's up and running, but it can take a while to start up and the build was timing out on quay. Instead of waiting a fixed amount of time and then checking for the output we expect, now we're making the tests pass as soon as they see the output they expect and otherwise timing out after 2 minutes, so that in either case we won't have a hung build on quay.
