### PR TITLE
Logstash config clean-up

### DIFF
--- a/templates/logstash.config.erb
+++ b/templates/logstash.config.erb
@@ -8,16 +8,24 @@ input {
   }
 }
 filter {
+  # Rewrite the @timestamp field from the time field in the Docker logs.
   date {
     match => [ "time", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'" ]
   }
-}
-filter {
+  # Extract the container id from the file that we're following.
   grok {
     match => [ "file", "/tmp/dockerlogs/%{BASE16NUM:container}" ]
   }
+  # The next two filters overwrite the host field with the first 12
+  # characters of the Docker container id.
+  grok {
+    match => ["container", "(?<container_short>.{12})"]
+  }
+  mutate {
+    rename => [ "container_short", "host" ]
+  }
+  <%= ENV['LOGSTASH_FILTERS'] || "" %>
 }
-<%= ENV['LOGSTASH_FILTERS'] || "" %>
 output {
-<%= ENV['LOGSTASH_OUTPUT_CONFIG'] || "stdout { codec => rubydebug }" %>
+  <%= ENV['LOGSTASH_OUTPUT_CONFIG'] || "stdout { codec => rubydebug }" %>
 }


### PR DESCRIPTION
- Putting all filter configs and output config under a single filter/config block
- Adding a filter to replace the hostname reported with the first 12 characters of the Docker id of the container being monitored
