### PR TITLE
Synchronize closing OpenSSL wrapper with underlying socket

### DIFF
--- a/syslog.rb
+++ b/syslog.rb
@@ -109,6 +109,7 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
             cert_store.set_default_paths
             ssl.cert_store = cert_store
             @client_socket = OpenSSL::SSL::SSLSocket.new(@client_socket, ssl)
+            @client_socket.sync_close
         end
         @client_socket.connect
     end


### PR DESCRIPTION
Hoping this will fix a hang that's happening on reconnect after the connection times out.
