### PR TITLE
Updating root CAs from Mozillas list, using Oracle JRE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
 FROM quay.io/aptible/ubuntu:14.04
 
-# Install curl, openjdk and ruby.
+# Install curl, oracle-java7 and ruby.
 RUN apt-get update && \
-    apt-get install -y curl openjdk-7-jre ruby && \
+    apt-get install -y python-software-properties software-properties-common
+RUN add-apt-repository ppa:webupd8team/java
+RUN echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
+RUN echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections
+RUN apt-get update && \
+    apt-get install -y curl oracle-java7-installer ruby && \
     apt-get clean
+
+# Download a snapshot of Mozilla's root certificates file, add it to the system certificates
+# at /etc/ssl/certs. We need this to validate the certificate chains of various off-brand
+# certs used by papertrail, logentries, etc.
+RUN curl -O https://papertrailapp.com/tools/papertrail-bundle.pem && \
+    echo "ab6a49f7788235bab954500c46e0c4a9c451797c papertrail-bundle.pem" | sha1sum -c - && \
+    mv papertrail-bundle.pem /usr/lib/ssl/cert.pem
 
 # Download the logstash tarball, verify it's SHA against a golden SHA, extract it.
 RUN curl -O https://download.elasticsearch.org/logstash/logstash/logstash-1.4.2.tar.gz && \

--- a/bin/run-gentleman-jerry.sh
+++ b/bin/run-gentleman-jerry.sh
@@ -7,6 +7,10 @@ if [ ! -f /tmp/certs/jerry.key ]; then
   echo "Expected key in /tmp/certs/jerry.key."
   exit 1
 fi
+if [ ! -f /usr/lib/ssl/cert.pem ]; then
+  echo "Expected root CA certificates in /usr/lib/ssl/cert.pem."
+  exit 1
+fi
 erb logstash.config.erb > logstash-1.4.2/logstash.config && \
 cd logstash-1.4.2 && \
-bin/logstash -f logstash.config
+SSL_CERT_FILE=/usr/lib/ssl/cert.pem bin/logstash -f logstash.config

--- a/test/gentlemanjerry.bats
+++ b/test/gentlemanjerry.bats
@@ -57,3 +57,23 @@ teardown() {
   [[ "$output" =~ "Using milestone 1 input plugin 'lumberjack'" ]]
   [[ "$output" =~ "Using milestone 1 output plugin 'syslog'" ]]
 }
+
+# We send syslog over TLS to various log drains-as-a-service and need to be able to
+# verify their certificate chains with the system certificates we have in
+# /usr/lib/ssl/cert.pem. This file is passed to logstash in the SSL_CERT_FILE environment
+# variable, which Ruby reads. These next few tests verify that this cert file works.
+
+@test "Gentleman Jerry can verify logs.papertrailapp.com:514's certificate" {
+  run timeout 3 openssl s_client -CAfile /usr/lib/ssl/cert.pem -connect logs.papertrailapp.com:514
+  [[ "$output" =~ "Verify return code: 0 (ok)" ]]
+}
+
+@test "Gentleman Jerry can verify logs2.papertrailapp.com:514's certificate" {
+  run timeout 3 openssl s_client -CAfile /usr/lib/ssl/cert.pem -connect logs.papertrailapp.com:514
+  [[ "$output" =~ "Verify return code: 0 (ok)" ]]
+}
+
+@test "Gentleman Jerry can verify api.logentries.com:25414's certificate" {
+  run timeout 3 openssl s_client -CAfile /usr/lib/ssl/cert.pem -connect api.logentries.com:25414
+  [[ "$output" =~ "Verify return code: 0 (ok)" ]]
+}


### PR DESCRIPTION
- Pulling down a set of root CAs from papertrail (via Mozilla's canonical list) and using it to verify certs by passing it as the SSL_CERT_FILE environment variable to logstash.
- I had problems running apt-get update && apt-get install openjdk-7 tonight, so switching to Oracle's JRE.
