### PR TITLE
Adding ability to restrict GentlemanJerry's JVM heap size

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Runtime behavior of Joe Cool can be modified by passing the following environmen
 * `LOGSTASH_FILTERS`: Any additional logstash filter definitions. Example: to rename the `log`
   field to `message`, set this variable to "filter { mutate { rename => ['log', 'message'] } }".
   Default: empty string.
+* `LOGSTASH_MAX_HEAP_SIZE`: Optional. Restricts the JVM max heap size for the logstash agent.
+  Default is "64M".
 
 ## Tests
 

--- a/bin/run-gentleman-jerry.sh
+++ b/bin/run-gentleman-jerry.sh
@@ -12,5 +12,16 @@ if [ ! -f /usr/lib/ssl/cert.pem ]; then
   exit 1
 fi
 erb logstash.config.erb > logstash-1.4.2/logstash.config && \
-cd logstash-1.4.2 && \
-SSL_CERT_FILE=/usr/lib/ssl/cert.pem bin/logstash -f logstash.config
+
+# SSL_CERT_FILE tells Ruby's OpenSSL library to use our custom CA roots (Which
+# is Mozilla's canonical set) to verify syslog TLS servers.
+export SSL_CERT_FILE=/usr/lib/ssl/cert.pem
+
+# LS_HEAP_SIZE sets the jvm Xmx argument when running logstash, which restricts
+# the max heap size. We set this to 64MB below unless it's overridden by
+# GentlemanJerry's LOGSTASH_HEAP_SIZE. We should be conservative with the heap
+# the GentlemanJerry uses since we have one running per account and on shared
+# instances we may have many accounts on the same machine.
+export LS_HEAP_SIZE=${LOGSTASH_MAX_HEAP_SIZE:-64M}
+
+cd logstash-1.4.2 && bin/logstash -f logstash.config


### PR DESCRIPTION
Exposing a flag that controls the max heap size, setting it to 64MB by default.
