### PR TITLE
Restarting GentlemanJerry when it dies

### DIFF
--- a/bin/run-gentleman-jerry.sh
+++ b/bin/run-gentleman-jerry.sh
@@ -24,4 +24,9 @@ export SSL_CERT_FILE=/usr/lib/ssl/cert.pem
 # instances we may have many accounts on the same machine.
 export LS_HEAP_SIZE=${LOGSTASH_MAX_HEAP_SIZE:-64M}
 
-cd logstash-1.4.2 && bin/logstash -f logstash.config
+cd logstash-1.4.2
+while true; do
+    bin/logstash -f logstash.config
+    sleep 1
+    echo "GentlemanJerry died, restarting..."
+done


### PR DESCRIPTION
This fixes issue https://github.com/aptible/gentlemanjerry/issues/11.

Our logstash processes are configured to die when their Java heap reaches 64MB. This usually happens when there's a temporary error keeping logstash from connecting or sending to an endpoint. We should always try again when this happens, so this patch continually restarts logstash after a 1 second wait whenever it dies. It also prints an error to stdout that we can grep for with scout so that we know when this is happening.
