### PR TITLE
Fix array/string discrepancy in syslog.rb 

### DIFF
--- a/syslog.rb
+++ b/syslog.rb
@@ -135,11 +135,11 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
     if rfc3164?
       timestamp = event.sprintf("%{+MMM dd HH:mm:ss}")
-      syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+appname+"["+procid+"]: "+event["message"]
+      syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+appname+"["+procid+"]: "+Array(event["message"]).first
     else
       msgid = event.sprintf(@msgid)
       timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZ}")
-      syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+appname+" "+procid+" "+msgid+" - "+event["message"]
+      syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+appname+" "+procid+" "+msgid+" - "+Array(event["message"]).first
     end
 
     @num_retries.times do |attempt|


### PR DESCRIPTION
_Don't merge. This is for demonstration purposes._

Sometimes (for reasons as yet unknown), event["message"] is an array instead of a string. This patch works around that case.
