### PR TITLE
V2 aptible logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/aptible/alpine
+FROM quay.io/aptible/alpine:3.3
 
 ENV JDK_VERSION openjdk7
 RUN apk update && apk-install curl "${JDK_VERSION}-jre-base" ruby java-cacerts
@@ -15,32 +15,50 @@ RUN JAVA_TRUSTSTORE=/usr/lib/jvm/java-1.7-openjdk/jre/lib/security/cacerts \
  && rm "$JAVA_TRUSTSTORE" \
  && ln -s "$SYSTEM_TRUSTSTORE" "$JAVA_TRUSTSTORE"
 
+ENV LOGSTASH_VERSION 1.5.1
+
 # Download the logstash tarball, verify its SHA against a golden SHA, extract it.
-RUN curl -O https://download.elastic.co/logstash/logstash/logstash-1.5.1.tar.gz && \
-    echo "526bf554d1f1e27354f3816c1a3576a83ac1ca05  logstash-1.5.1.tar.gz" | sha1sum -c - && \
-    tar zxf logstash-1.5.1.tar.gz
+RUN curl -O "https://download.elastic.co/logstash/logstash/logstash-${LOGSTASH_VERSION}.tar.gz" && \
+    echo "526bf554d1f1e27354f3816c1a3576a83ac1ca05  logstash-${LOGSTASH_VERSION}.tar.gz" | sha1sum -c - && \
+    tar zxf "logstash-${LOGSTASH_VERSION}.tar.gz" && \
+    rm "logstash-${LOGSTASH_VERSION}.tar.gz"
 
 # Update http output gem
 # Install our syslog output implementation
 RUN apk-install git && \
-    grep -v 'logstash-output-http' /logstash-1.5.1/Gemfile > /logstash-1.5.1/Gemfile.tmp && \
-    mv /logstash-1.5.1/Gemfile.tmp /logstash-1.5.1/Gemfile && \
+    GEMFILE="/logstash-${LOGSTASH_VERSION}/Gemfile" && \
+    grep -v 'logstash-output-http' "$GEMFILE" > "${GEMFILE}.tmp" && \
+    mv "${GEMFILE}.tmp" "$GEMFILE" && \
+    grep -v 'logstash-output-redis' "$GEMFILE" > "${GEMFILE}.tmp" && \
+    mv "${GEMFILE}.tmp" "$GEMFILE" && \
     echo "gem 'logstash-output-http', :git => 'https://github.com/krallin/logstash-output-http'," \
-         ":ref => '77de2b1'" >> /logstash-1.5.1/Gemfile && \
+         ":ref => '77de2b1'" >> "$GEMFILE" && \
     echo "gem 'logstash-mixin-http_client', :git => 'https://github.com/krallin/logstash-mixin-http_client'," \
-         ":ref => '68fa376'" >> /logstash-1.5.1/Gemfile && \
+         ":ref => '68fa376'" >> "$GEMFILE" && \
     echo "gem 'logstash-output-syslog', :git => 'https://github.com/aaw/logstash-output-syslog'," \
-         ":branch => 'aptible'" >> /logstash-1.5.1/Gemfile && \
-    /logstash-1.5.1/bin/plugin install --no-verify && \
+         ":branch => 'aptible'" >> "$GEMFILE" && \
+    echo "gem 'logstash-output-redis', :git => 'https://github.com/krallin/logstash-output-redis'," \
+         ":ref => '3fa4b3e'" >> "$GEMFILE" && \
+    "/logstash-${LOGSTASH_VERSION}/bin/plugin" install --no-verify && \
     apk del git
 
 # The logstash-output-elasticsearch plugin needs log4j-1.2.17.jar added to its
 # runtime dependencies so that we can suppress some of the Java logging. This
 # jar already exists in the dependencies for some other plugins, so we just copy
 # from one of them.
-RUN cp /logstash-1.5.1/vendor/bundle/jruby/1.9/gems/*/vendor/jar-dependencies/runtime-jars/log4j-1.2.17.jar \
-       /logstash-1.5.1/vendor/bundle/jruby/1.9/gems/logstash-output-elasticsearch*/vendor/jar-dependencies/runtime-jars/
+RUN cp "/logstash-${LOGSTASH_VERSION}/vendor/bundle/jruby/1.9/gems/"*"/vendor/jar-dependencies/runtime-jars/log4j-1.2.17.jar" \
+       "/logstash-${LOGSTASH_VERSION}/vendor/bundle/jruby/1.9/gems/logstash-output-elasticsearch"*"/vendor/jar-dependencies/runtime-jars/"
 
+# The Redis output is used with a local Redis, so we need to isntall it. We also
+# install stunnel as a reverse SSL proxy (we need to install it from testing though,
+# as it's not in the main Alpine repository yet). Finally, we also pull in coreutils,
+# which is a useful convenience in our tests.
+RUN apk-install coreutils redis && \
+    apk-install --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" stunnel
+
+ADD templates/stunnel.conf /stunnel.conf
+ADD templates/redis.conf.erb /redis.conf.erb
+ADD templates/load-message.lua /load-message.lua
 ADD templates/logstash.config.erb /logstash.config.erb
 ADD templates/log4j.properties /log4j.properties
 ADD bin/run-gentleman-jerry.sh run-gentleman-jerry.sh
@@ -52,5 +70,10 @@ RUN /tmp/test/run_tests.sh
 # A volume containing a certificate pair named jerry.key/jerry.crt must be mounted into
 # this directory on the container.
 VOLUME ["/tmp/certs"]
+
+# Lumberjack
+EXPOSE 5000
+# Redis (used if the drain is a tail)
+EXPOSE 6000
 
 CMD ["/bin/bash", "run-gentleman-jerry.sh"]

--- a/bin/run-gentleman-jerry.sh
+++ b/bin/run-gentleman-jerry.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -o errexit
 
-LOGSTASH_VERSION="1.5.1"
 if [ ! -f /tmp/certs/jerry.crt ]; then
   echo "Expected certificate in /tmp/certs/jerry.crt."
   exit 1

--- a/bin/run-gentleman-jerry.sh
+++ b/bin/run-gentleman-jerry.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o errexit
+
 LOGSTASH_VERSION="1.5.1"
 if [ ! -f /tmp/certs/jerry.crt ]; then
   echo "Expected certificate in /tmp/certs/jerry.crt."
@@ -8,7 +10,28 @@ if [ ! -f /tmp/certs/jerry.key ]; then
   echo "Expected key in /tmp/certs/jerry.key."
   exit 1
 fi
-erb logstash.config.erb > logstash-${LOGSTASH_VERSION}/logstash.config && \
+
+if [[ -n "$REDIS_PASSWORD" ]]; then
+  echo "Generating Redis configuration"
+  erb redis.conf.erb > /redis.conf
+
+  echo "Starting stunnel (SSL reverse proxy)"
+  stunnel /stunnel.conf &
+
+  echo "Starting Redis"
+  redis-server /redis.conf &
+
+  # Now, load the script
+  echo "Loading script"
+  until LOAD_SCRIPT_SHA="$(redis-cli -a "$REDIS_PASSWORD" SCRIPT LOAD "$(cat "/load-message.lua")")"; do
+    echo "Redis is not up yet... Retrying in 1s"
+    sleep 1
+  done
+  export LOAD_SCRIPT_SHA
+fi
+
+echo "Generating Logstash configuration"
+erb logstash.config.erb > logstash-${LOGSTASH_VERSION}/logstash.config
 
 # LS_HEAP_SIZE sets the jvm Xmx argument when running logstash, which restricts
 # the max heap size. We set this to 64MB below unless it's overridden by

--- a/templates/load-message.lua
+++ b/templates/load-message.lua
@@ -1,19 +1,21 @@
-local rawMessage = ARGV[1]
-
 -- Some constants to control the behavior. Eventually, we might want to control
 -- those via Redis keys.
 local bufferBucketInterval = 60 -- How long (in seconds) should a buffer bucket be?
 local bufferBucketCount = 20    -- How many buffer buckets to retain (memory permitting)
 
--- First, parse the message and figure out the app
-local message = cjson.decode(rawMessage)
+-- First, parse the incoming JSON message.
+local message = cjson.decode(ARGV[1])
+
+-- Prepare a Message ID, add it to the message, and serialize.
+message.redisMessageId = redis.call("INCR", "last-redisMessageId")
+local messageJson = cjson.encode(message)
 
 -- It's OK to index messages by app name, since app names are unique within an
 -- environment.
 local appName = message.app
 
 -- First, deliver the message to listeners.
-local publishRet = redis.call("PUBLISH", "stream-" .. appName, rawMessage)
+local publishRet = redis.call("PUBLISH", "stream-" .. appName, messageJson)
 
 -- Now, we need to add the key to a buffer. We actually want to use multiple buffers
 -- for each log stream, so that the Redis volatile-ttl policy will automatically
@@ -26,7 +28,7 @@ local bufferBucketName = "buffer-bucket-" .. appName .. "-" .. bufferBucketIndex
 -- Add the message to the bucket, and set (or refresh) a TTL on the bucket.
 -- This will ensure the message is eventually expired, and will also be used
 -- by Redis to inform OOM eviction decisions.
-redis.call("LPUSH", bufferBucketName, rawMessage)
+redis.call("LPUSH", bufferBucketName, messageJson)
 redis.call("EXPIRE", bufferBucketName, bufferBucketInterval * bufferBucketCount)
 
 -- Finally, store the buffer name in our buffer map. The buffer map is a sorted

--- a/templates/load-message.lua
+++ b/templates/load-message.lua
@@ -1,20 +1,22 @@
--- Some constants to control the behavior. Eventually, we might want to control
--- those via Redis keys.
-local bufferBucketInterval = 60 -- How long (in seconds) should a buffer bucket be?
-local bufferBucketCount = 20    -- How many buffer buckets to retain (memory permitting)
+-- Some parameters to control the behavior. Can be set via Redis keys.
+-- How long (in seconds) should a given buffer bucket be?
+local pBufferBucketInterval = tonumber(redis.call("GET", "conf-bufferBucketInterval")) or 60
+-- How many buffer buckets should we retain?
+local pBufferBucketCount = tonumber(redis.call("GET", "conf-bufferBucketCount")) or 20
 
--- First, parse the incoming JSON message.
+-- Derived parameters
+local pBufferLifetime = pBufferBucketInterval * pBufferBucketCount
+
+-- First, parse and restructure the incoming message.
 local message = cjson.decode(ARGV[1])
-
--- Prepare a Message ID, add it to the message, and serialize.
-message.redisMessageId = redis.call("INCR", "last-redisMessageId")
+message.redisMessageId = tonumber(redis.call("INCR", "last-redisMessageId"))
 local messageJson = cjson.encode(message)
 
 -- It's OK to index messages by app name, since app names are unique within an
 -- environment.
 local appName = message.app
 
--- First, deliver the message to listeners.
+-- Now, make sure we deliver the message to subscribers waiting for it.
 local publishRet = redis.call("PUBLISH", "stream-" .. appName, messageJson)
 
 -- Now, we need to add the key to a buffer. We actually want to use multiple buffers
@@ -22,26 +24,29 @@ local publishRet = redis.call("PUBLISH", "stream-" .. appName, messageJson)
 -- expire old logs for us, without entirely trimming the buffers. To that end, we
 -- buffer logs into a new bucket every minute, which means we'll have 10 active
 -- buckets per log stream, since our TTL on log buffers is 10 minutes.
-local bufferBucketIndex = math.floor(message.unix_timestamp / bufferBucketInterval)
+local bufferBucketIndex = math.floor(message.unix_timestamp / pBufferBucketInterval) * pBufferBucketInterval
 local bufferBucketName = "buffer-bucket-" .. appName .. "-" .. bufferBucketIndex
 
 -- Add the message to the bucket, and set (or refresh) a TTL on the bucket.
 -- This will ensure the message is eventually expired, and will also be used
 -- by Redis to inform OOM eviction decisions.
 redis.call("LPUSH", bufferBucketName, messageJson)
-redis.call("EXPIRE", bufferBucketName, bufferBucketInterval * bufferBucketCount)
+redis.call("EXPIREAT", bufferBucketName, message.unix_timestamp + pBufferLifetime)
 
--- Finally, store the buffer name in our buffer map. The buffer map is a sorted
--- set where we sort buffer bucket names by their index, which means we can
+-- Finally, store the buffer name in a buffer map. The buffer map is a sorted
+-- set where we sort buffer bucket names by their timestamp, which means we can
 -- query recent logs by hitting the more recent records in the set.
 local bufferMapName = "buffer-map-" .. appName
 redis.call("ZADD", bufferMapName, bufferBucketIndex, bufferBucketName)
 
--- Only retain the address of the buffers that may not have expired yet.
-redis.call("ZREMRANGEBYRANK", bufferMapName, 0, -bufferBucketCount)
+-- Truncate the buffer map to only retain the address of the buffers that may
+-- not have expired yet.
+redis.call("ZREMRANGEBYRANK", bufferMapName, 0, -pBufferBucketCount - 1)
 
--- Set an TTL on the buffer map to make sure it too eventually gets evited.
-redis.call("EXPIRE", bufferMapName, bufferBucketInterval * bufferBucketCount * 10)
+-- Set a TTL to eventually expire the buffer map as well, but make sure it's
+-- after the TTL of the last member. To do so, we ensure the buffer map expires
+-- over one lifetime after we touched one of its members for the last time.
+redis.call("EXPIRE", bufferMapName, pBufferLifetime + pBufferBucketInterval)
 
 -- Finally, return the number of subscribers for consistency with PUBLISH
 return publishRet

--- a/templates/load-message.lua
+++ b/templates/load-message.lua
@@ -1,0 +1,45 @@
+local rawMessage = ARGV[1]
+
+-- Some constants to control the behavior. Eventually, we might want to control
+-- those via Redis keys.
+local bufferBucketInterval = 60 -- How long (in seconds) should a buffer bucket be?
+local bufferBucketCount = 20    -- How many buffer buckets to retain (memory permitting)
+
+-- First, parse the message and figure out the app
+local message = cjson.decode(rawMessage)
+
+-- It's OK to index messages by app name, since app names are unique within an
+-- environment.
+local appName = message.app
+
+-- First, deliver the message to listeners.
+local publishRet = redis.call("PUBLISH", "stream-" .. appName, rawMessage)
+
+-- Now, we need to add the key to a buffer. We actually want to use multiple buffers
+-- for each log stream, so that the Redis volatile-ttl policy will automatically
+-- expire old logs for us, without entirely trimming the buffers. To that end, we
+-- buffer logs into a new bucket every minute, which means we'll have 10 active
+-- buckets per log stream, since our TTL on log buffers is 10 minutes.
+local bufferBucketIndex = math.floor(message.unix_timestamp / bufferBucketInterval)
+local bufferBucketName = "buffer-bucket-" .. appName .. "-" .. bufferBucketIndex
+
+-- Add the message to the bucket, and set (or refresh) a TTL on the bucket.
+-- This will ensure the message is eventually expired, and will also be used
+-- by Redis to inform OOM eviction decisions.
+redis.call("LPUSH", bufferBucketName, rawMessage)
+redis.call("EXPIRE", bufferBucketName, bufferBucketInterval * bufferBucketCount)
+
+-- Finally, store the buffer name in our buffer map. The buffer map is a sorted
+-- set where we sort buffer bucket names by their index, which means we can
+-- query recent logs by hitting the more recent records in the set.
+local bufferMapName = "buffer-map-" .. appName
+redis.call("ZADD", bufferMapName, bufferBucketIndex, bufferBucketName)
+
+-- Only retain the address of the buffers that may not have expired yet.
+redis.call("ZREMRANGEBYRANK", bufferMapName, 0, -bufferBucketCount)
+
+-- Set an TTL on the buffer map to make sure it too eventually gets evited.
+redis.call("EXPIRE", bufferMapName, bufferBucketInterval * bufferBucketCount * 10)
+
+-- Finally, return the number of subscribers for consistency with PUBLISH
+return publishRet

--- a/templates/load-message.lua
+++ b/templates/load-message.lua
@@ -7,25 +7,37 @@ local pBufferBucketCount = tonumber(redis.call("GET", "conf-bufferBucketCount"))
 -- Derived parameters
 local pBufferLifetime = pBufferBucketInterval * pBufferBucketCount
 
--- First, parse and restructure the incoming message.
+-- First, parse and restructure the incoming message. We're pretty much
+-- guaranteed this will be valid JSON, otherwise Gentlemanjerry (Logstash)
+-- wouldn't send it to us (so, if it's not valid JSON, then something else must
+-- have sent the message, and it's A-OK to bail with an exception).
 local message = cjson.decode(ARGV[1])
 message.redisMessageId = tonumber(redis.call("INCR", "last-redisMessageId"))
 local messageJson = cjson.encode(message)
 
--- It's OK to index messages by app name, since app names are unique within an
--- environment.
-local appName = message.app
+-- We're going to need to know the app name to route messages, and the
+-- timestamp for the message. Unfortunately we're not guaranteed that those
+-- fields will be here. In particular, app may be missing if JoeCool didn't
+-- send it or if Gentlemanjerry failed to parse it. When that happens, we'll
+-- just route this message to a junk bucket. This is unlikely to be useful for
+-- users, but may let us troubleshoot errors more easily.
+local messageAppName = message.app or "JUNK"
+local messageTimestamp = message.unix_timestamp or 0
 
--- Now, make sure we deliver the message to subscribers waiting for it.
-local publishRet = redis.call("PUBLISH", "stream-" .. appName, messageJson)
+-- We'll index messages by app name, which is fine because app names are unique
+-- within an environment and Log Drains are scoped to an environment, and
+-- because users query logs on a per-app basis.
+
+-- Make sure we deliver the message to subscribers waiting for it.
+local publishRet = redis.call("PUBLISH", "stream-" .. messageAppName, messageJson)
 
 -- Now, we need to add the key to a buffer. We actually want to use multiple buffers
 -- for each log stream, so that the Redis volatile-ttl policy will automatically
 -- expire old logs for us, without entirely trimming the buffers. To that end, we
 -- buffer logs into a new bucket every minute, which means we'll have 10 active
 -- buckets per log stream, since our TTL on log buffers is 10 minutes.
-local bufferBucketIndex = math.floor(message.unix_timestamp / pBufferBucketInterval) * pBufferBucketInterval
-local bufferBucketName = "buffer-bucket-" .. appName .. "-" .. bufferBucketIndex
+local bufferBucketIndex = math.floor(messageTimestamp / pBufferBucketInterval) * pBufferBucketInterval
+local bufferBucketName = "buffer-bucket-" .. messageAppName .. "-" .. bufferBucketIndex
 
 -- New messages are added at the right end of the bucket, which means that
 -- messages will be sorted from first received to last received (note: the
@@ -36,12 +48,12 @@ redis.call("RPUSH", bufferBucketName, messageJson)
 -- Set a  TTL, which ensures we eventually expire the bucket, and will be used
 -- by Redis to inform OOM eviction decisions (oldest buckets - which will
 -- expire the soonest - are evicted first).
-redis.call("EXPIREAT", bufferBucketName, message.unix_timestamp + pBufferLifetime)
+redis.call("EXPIREAT", bufferBucketName, messageTimestamp + pBufferLifetime)
 
 -- Finally, store the bucket name in a buffer map. The buffer map is a sorted
 -- set where we sort bucket names by their timestamp. Thus, when we query the
 -- set via ZRANGE ... 0 -1, we'll get the buckets from oldest to newest.
-local bufferMapName = "buffer-map-" .. appName
+local bufferMapName = "buffer-map-" .. messageAppName
 redis.call("ZADD", bufferMapName, bufferBucketIndex, bufferBucketName)
 
 -- Truncate the buffer map to only retain the address of the buffers that may

--- a/templates/logstash.config.erb
+++ b/templates/logstash.config.erb
@@ -27,5 +27,11 @@ filter {
   <%= ENV['LOGSTASH_FILTERS'] || "" %>
 }
 output {
-  <%= ENV['LOGSTASH_OUTPUT_CONFIG'] || "stdout { codec => rubydebug }" %>
+  <%=
+    # The block is only called if there is a match, which ensures we crash
+    # if __LOAD_SCRIPT_SHA__ was provided but not LOAD_SCRIPT_SHA, but proceed
+    # without error if __LOAD_SCRIPT_SHA__ was not provided.
+    (ENV['LOGSTASH_OUTPUT_CONFIG'] || "stdout { codec => rubydebug }")
+    .gsub('__LOAD_SCRIPT_SHA__') { |_| ENV.fetch('LOAD_SCRIPT_SHA') }
+  %>
 }

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -1,0 +1,26 @@
+# Don't daemonize, since we want the logs to go to stdout
+daemonize no
+
+# Only listen on localhost. We'll expose Redis over SSL via stunnel for other
+# traffic.
+bind 127.0.0.1
+
+# It's fine for clients to be idle, provided they are alive.
+timeout 0
+tcp-keepalive 60
+
+# We're using Redis to route logs under pub / sub.  No use saving anything, so
+# we'll disable RDB and AOF persistence.
+save ""
+appendonly no
+
+# Enforce authentication using the drain password.
+requirepass <%= ENV['REDIS_PASSWORD'] %>
+
+# Allow up to 8 MB of log buffer storage.
+maxmemory 8mb
+
+# If we hit the memory limit, then kill the oldest key.
+maxmemory-policy volatile-ttl
+
+# Rename all the other commands here to disable them...? (rename-command)

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -24,3 +24,5 @@ maxmemory 8mb
 maxmemory-policy volatile-ttl
 
 # Rename all the other commands here to disable them...? (rename-command)
+# We only need and will ever use one database
+databases 1

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -23,6 +23,9 @@ maxmemory <%= ENV['REDIS_ALLOWED_MEMORY'] || '8mb' %>
 # If we hit the memory limit, then kill the oldest key.
 maxmemory-policy volatile-ttl
 
-# Rename all the other commands here to disable them...? (rename-command)
 # We only need and will ever use one database
 databases 1
+
+# Disable the CONFIG command: we don't want users (accidentally or
+# deliberately) abusing a tail drain as a redis server.
+rename-command CONFIG ""

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -17,8 +17,8 @@ appendonly no
 # Enforce authentication using the drain password.
 requirepass <%= ENV['REDIS_PASSWORD'] %>
 
-# Allow up to 8 MB of log buffer storage.
-maxmemory 8mb
+# Allow up to 8 MB of log buffer storage by default.
+maxmemory <%= ENV['REDIS_ALLOWED_MEMORY'] || '8mb' %>
 
 # If we hit the memory limit, then kill the oldest key.
 maxmemory-policy volatile-ttl

--- a/templates/stunnel.conf
+++ b/templates/stunnel.conf
@@ -1,0 +1,17 @@
+; Run in the foreground, we'll have the shell send stunnel to the background.
+foreground = yes
+output=/dev/stdout
+
+; No pid file
+pid=
+
+; Use the gentlemanjerry credentials
+cert=/tmp/certs/jerry.crt
+key=/tmp/certs/jerry.key
+
+; SSLconfiguration
+options=NO_SSLv2
+
+[redis]
+accept=6000
+connect=6379

--- a/templates/stunnel.conf
+++ b/templates/stunnel.conf
@@ -12,6 +12,9 @@ key=/tmp/certs/jerry.key
 ; SSLconfiguration
 options=NO_SSLv2
 
+; Warnings (default is notice, which includes each connetion)
+debug = 4
+
 [redis]
 accept=6000
 connect=6379

--- a/test/feed-logstash.config
+++ b/test/feed-logstash.config
@@ -1,0 +1,26 @@
+input {
+    generator {
+      lines => [
+        "line 1",
+        "line 2"
+      ]
+      count => 1
+  }
+}
+
+filter {
+  mutate {
+    add_field => {
+      "app" => "myapp"
+    }
+  }
+}
+
+output {
+  lumberjack {
+    codec => json
+    hosts => ["127.0.0.1"]
+    port => 5000
+    ssl_certificate => "/tmp/certs/jerry.crt"
+  }
+}

--- a/test/gentlemanjerry.bats
+++ b/test/gentlemanjerry.bats
@@ -88,6 +88,10 @@ teardown() {
   pgrep stunnel
   pgrep redis-server
 
+  # Check that we can connect over ssl
+  run timeout 3 openssl s_client -CAfile "/tmp/certs/jerry.crt" -connect localhost:6000
+  [[ "$output" =~ "Verify return code: 0 (ok)" ]]
+
   # Now, send some traffic into Logstash
   "/logstash-${LOGSTASH_VERSION}/bin/logstash" -f "${BATS_TEST_DIRNAME}/feed-logstash.config"
 

--- a/test/gentlemanjerry.bats
+++ b/test/gentlemanjerry.bats
@@ -36,12 +36,18 @@ wait_for_gentlemanjerry() {
   # output against what we expect.
   jerry_log_file="/tmp/logs/jerry.logs"
 
-  /bin/bash run-gentleman-jerry.sh > "$jerry_log_file" &
-  timeout -t 120 grep -q "Logstash startup completed" <(tail -f "$jerry_log_file") || {
-    echo "Gentlemanjerry did not start in time, or failed to start:"
-    cat "$jerry_log_file"
-    return 1
-  }
+  /bin/bash run-gentleman-jerry.sh 2>&1 > "$jerry_log_file" &
+
+  for i in $(seq 1 120); do
+    if grep -q "Logstash startup completed" "$jerry_log_file"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Gentlemanjerry did not start in time, or failed to start:"
+  cat "$jerry_log_file"
+  return 1
 }
 
 kill_gentlemanjerry() {

--- a/test/load-message.bats
+++ b/test/load-message.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+
+function redis-cli() {
+  # By default, redis-cli buffers its output, so it doesn't work too well in a
+  # pipeline: https://github.com/antirez/redis/issues/2074
+  (exec stdbuf -i0 -o0 -e0 redis-cli -a "$REDIS_PASSWORD" "$@")
+}
+
+function make_message() {
+  local when="$1"
+  local what="$2"
+  printf '{ "unix_timestamp": %d, "app": "myapp", "log": "%s" }' "$when" "$what"
+}
+
+function dump_buffers() {
+  local keys="$(redis-cli ZRANGE buffer-map-myapp 0 -1)"
+  local n_buffers=0
+  for key in $keys; do
+    n_buffers=$((n_buffers + 1))
+    redis-cli LRANGE "$key" 0 -1 >> "$BUFFER_FILE"
+  done
+  echo "$n_buffers"
+}
+
+function count_unique_messages() {
+  local fname="$1"
+  local real_count="$(grep -Eo '"redisMessageId":.*\d+' "$fname" | sort | uniq | wc -l)"
+  echo "$real_count"
+}
+
+function wait_for() {
+  for _ in $(seq 1 "$((${WAIT:=2} + 1))" ); do
+    if "$@" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Command timed out:" "$@"
+  return 1
+}
+
+setup() {
+  export REDIS_PASSWORD="foobar123"
+  export TEST_WORK_DIR="/tmp/load-message-tests"
+  export BUFFER_FILE="${TEST_WORK_DIR}/buffer.log"
+  export STREAM_FILE="${TEST_WORK_DIR}/stream.log"
+
+  mkdir -p "$TEST_WORK_DIR"
+
+  export TEST_CONFIG="${TEST_WORK_DIR}/redis.conf"
+  REDIS_ALLOWED_MEMORY='2mb' erb /redis.conf.erb > "$TEST_CONFIG"
+  redis-server "$TEST_CONFIG" &
+  export REDIS_SERVER_PID=$!
+
+  wait_for redis-cli GET test
+
+  redis-cli SUBSCRIBE "stream-myapp" 2>&1 > "$STREAM_FILE" &
+  export REDIS_SUBSCRIBER_PID=$!
+
+  LOAD_SCRIPT_SHA="$(redis-cli SCRIPT LOAD "$(cat "/load-message.lua")")"
+  export LOAD_SCRIPT_SHA
+}
+
+teardown() {
+  # We use SIGKILL here so as to avoid timing issues (i.e. having to wait for those
+  # processes to exit cleanly. That's probably fine for now).
+  kill -KILL "$REDIS_SUBSCRIBER_PID"
+  kill -KILL "$REDIS_SERVER_PID"
+  rm -r "$TEST_WORK_DIR"
+}
+
+@test "It delivers incoming logs to subscribers" {
+  ts="$(date +%s)"
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$ts" "Some message")"
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$ts" "More message")"
+
+  wait_for grep "Some message" "$STREAM_FILE"
+  wait_for grep "More message" "$STREAM_FILE"
+}
+
+@test "It buffers recent incoming logs" {
+  ts="$(date +%s)"
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$ts" "Some message")"
+
+  wait_for grep "Some message" "$STREAM_FILE"
+
+  # Check that we have one buffer, and that the message is in it.
+  dump_buffers
+  [[ "$(count_unique_messages "$BUFFER_FILE")" -eq 1 ]]
+  grep "Some message" "$BUFFER_FILE"
+}
+
+@test "It delivers outdated incoming logs to subscribers, but does not buffer them" {
+  now="$(date +%s)"
+  ts="$((now - 3600))"  # 1 hour old
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$ts" "Some message")"
+
+  wait_for grep "Some message" "$STREAM_FILE"
+
+  # Check that no messages were buffered
+  dump_buffers
+  [[ "$(count_unique_messages "$BUFFER_FILE")" -eq 0 ]]
+  run grep "Some message" "$BUFFER_FILE"
+  [[ "$status" -gt 0 ]]
+}
+
+@test "It breaks down messages in buffer buckets, and expires them" {
+  redis-cli SET "conf-bufferBucketCount" 2
+  now="$(date +%s)"
+
+  # Send some messages now
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$now" "Bucket 0 message 1")"
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$now" "Bucket 0 message 2")"
+
+  # Send some that are a minute old
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$((now - 60))" "Bucket 1 message 1")"
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$((now - 60))" "Bucket 1 message 2")"
+
+  # And some that are 2 minutes old
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$((now - 120))" "Bucket 2 message 1")"
+  redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$(make_message "$((now - 120))" "Bucket 2 message 2")"
+
+  # Now, we expect to only find a total of 4 messages, in 2 buckets.
+  bucket_count="$(dump_buffers)"
+
+  [[ "$bucket_count" -eq 2 ]]
+  [[ "$(count_unique_messages "$STREAM_FILE")" -eq "6" ]]
+  [[ "$(count_unique_messages "$BUFFER_FILE")" -eq "4" ]]
+}
+
+@test "It does not run out of memory" {
+  # We'll send messages that are about 40kB. We should not be able to store
+  # more than 50 of those, so we'll send 100.
+  n_messages=100
+
+  ts="$(date +%s)"
+  payload="$(head -c "$((3072 * 10))" "/dev/urandom" | base64 | tr --delete '\n')"
+
+  msg="$(make_message "$ts" "$payload")"
+  for i in $(seq 1 "$n_messages"); do
+    redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "$msg"
+  done
+  dump_buffers
+
+  # Check that all messages were received, but that some were discarded.
+  [[ "$(count_unique_messages "$STREAM_FILE")" -eq "$n_messages" ]]
+  [[ "$(count_unique_messages "$BUFFER_FILE")" -lt "$n_messages" ]]
+}

--- a/test/load-message.bats
+++ b/test/load-message.bats
@@ -136,6 +136,11 @@ teardown() {
   [[ ${lines[3]} =~ "Bucket 2 message 2" ]]
 }
 
+@test "It does not error upon receving a junk message" {
+  run redis-cli EVALSHA "$LOAD_SCRIPT_SHA" 0 "{}"
+  [[ ! "$output" =~ "ERR" ]]
+}
+
 @test "It does not run out of memory" {
   # We'll send messages that are about 40kB. We should not be able to store
   # more than 50 of those, so we'll send 100.


### PR DESCRIPTION
(This is part of a series of PRs to add support for `aptible logs` on v2)

This PR adds several new features for GentlemanJerry, which boil down to allowing Redis to run as a co-process to buffer and route logs. Here's how it works:

- If the `REDIS_PASSWORD` environment variable is set, then Gentlemanjerry will start a Redis co-process (note: we might want to be more explicit and have a `START_REDIS` variable instead — let me know). It also starts `stunnel` to reverse proxy Redis' traffic and provide SSL (using the same certificate as Gentlemanjerry). 
- It loads a Lua script in Redis (more on what this script does below), and makes its SHA available as en environment variable, which can be reused in the Logstash output configuration. This is a bit of a hack, but the goal is to allow Sweetness to provide a configuration that references the Lua script's SHA. The hack is made necessary by the fact that Sweetness and Gentlemanjerry share the responsibility of coming up with a Logstash configuration, and in this particular case, only Gentlemanjerry knows the SHA. We could (if we wanted) address this by having Sweetness provide structured configuration parameters to Gentlemanjerry as environment variables, rather than as an unstructured `LOGSTASH_OUTPUT_CONFIGURATION` blob (which means we'd move the responsibility of preparing the configuration to Gentlemanjerry itself).

Sweetness can then provide a configuration that submits logs to Redis locally, by executing the Lua script with the new log message (formatted as JSON) as input (I'll be adding this PR in Sweetness in a little bit). To do so, it uses a slightly patched version (the patch itself is a few lines — I'll try to upstream it) of the Logstash Redis output that allows calling a Lua script.

Then, retrieving logs is simply a matter of querying Redis for them (which Dumptruck will do — PR for that is coming as well).

--

Now, this PR probably deserves an explanation of what the Lua script does, since that's easily 50% of the functionality. In a nutshell, the goal of the Lua script is to publish logs to a queue (so they can be streamed by Dumptruck if a client is connected), buffer them (so recent logs can be output in bulk when a client connects), and ensure we use our memory as effectively as possible (I've limited Redis to 8MB of memory for the moment, but we can alter that limit if we want). 

A side responsibility for the script is to help Dumptruck avoid outputting the same log entry to customers twice (in case it received the same log message via streaming and buffering).

It achieves that by:

- Adding a unique ID on each log message it receives. This is guaranteed to increase monotonically (unless we hit 2**63 log messages..!).
- Publishing every log message it receives to a per-app stream (this depends on a PR I'm sending in Joecool).
- Bucketing logs in lists that represent 60 second intervals, and maintaining a "log map" so that Dumptruck can find those lists. We retain at most 20 buckets, and bucket expires after 20 minutes (which means we retain logs for 20 minutes).

When OOM, Redis is configured to evict keys that are the closest to their expiry, which means the oldest 60-second bucket(s) will be evicted.


--

That's it! Thoughts @fancyremarker @aaw ?