### PR TITLE
stunel: force connection over IPV4

### DIFF
--- a/templates/stunnel.conf
+++ b/templates/stunnel.conf
@@ -17,4 +17,4 @@ debug = 4
 
 [redis]
 accept=6000
-connect=6379
+connect=127.0.0.1:6379


### PR DESCRIPTION
By default, stunnel attempts to connect to Redis over IPv6, which
results in a bunch of `2016.06.30 18:22:11 LOG3[7]: s_connect: connect
::1:6379: Connection refused (111)` log messages (stunnel then attempts
to connect over IPv4, which succeeds, so it's mostly a cosmetic
problem).

This updates the stunnel configuration to stick to IPv4.


---

cc @fancyremarker 