### PR TITLE
Restart GentlemanJerry when it crashes

### DIFF
--- a/bin/run-gentleman-jerry.sh
+++ b/bin/run-gentleman-jerry.sh
@@ -30,7 +30,7 @@ if [[ -n "$REDIS_PASSWORD" ]]; then
 fi
 
 echo "Generating Logstash configuration"
-erb logstash.config.erb > logstash-${LOGSTASH_VERSION}/logstash.config
+erb logstash.config.erb > "logstash-${LOGSTASH_VERSION}/logstash.config"
 
 # LS_HEAP_SIZE sets the jvm Xmx argument when running logstash, which restricts
 # the max heap size. We set this to 64MB below unless it's overridden by
@@ -45,9 +45,10 @@ export LS_HEAP_SIZE=${LOGSTASH_MAX_HEAP_SIZE:-64M}
 # custom log4j.properties configuration.
 export LS_JAVA_OPTS="-Dlog4j.configuration=file:/log4j.properties"
 
-cd logstash-${LOGSTASH_VERSION}
+cd "logstash-${LOGSTASH_VERSION}"
 while true; do
-    bin/logstash -f logstash.config
+    # Ignore errors to ensure we stay up
+    bin/logstash -f logstash.config || true
     sleep 1
     echo "GentlemanJerry died, restarting..."
 done

--- a/test/gentlemanjerry.bats
+++ b/test/gentlemanjerry.bats
@@ -114,8 +114,9 @@ teardown() {
   generate_certs
   export LOGSTASH_OUTPUT_CONFIG="syslog { facility => \"daemon\" host => \"127.0.0.1\" port => 514 severity => \"emergency\" }"
   wait_for_gentlemanjerry
-  pkill -f 'java.*logstash'
-  run timeout 120 grep -q "GentlemanJerry died, restarting..." <(tail -f /tmp/logs/jerry.logs)
+  # Force an unclean shutdown to avoid GentlemanJerry exiting with 0
+  pkill -KILL -f 'java.*logstash'
+  timeout 10 grep -q "GentlemanJerry died, restarting..." <(tail -f /tmp/logs/jerry.logs)
   pkill -f 'tail'
   run timeout 120 grep -q "Logstash startup completed" <(tail -f /tmp/logs/jerry.logs)
   pkill -f 'tail'


### PR DESCRIPTION
When we shipped Aptible Logs on v2, I introduced a regression by adding
`-o errexit` to the `run-gentleman-jerry.sh` script, which resulted in
not restarting GentlemanJerry if it exited after an unclean shutdown
(which it sometimes does when it uses too much memory).

Unfortunately, we missed this because our tests were inadvertently doing
a clean shutdown of GentlemanJerry, so it exited with 0, and so it
wasn't causing the script to exit.

This patch fixes the runner script by ignoring errors there, and fixes
the tests by forcing an unclean shutdown.

--

cc @fancyremarker 