### PR TITLE
Add multiple container size flavors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,13 @@ env:
   global:
     - DOCKER_CONFIG=./.docker
   matrix:
-    - TAG=master
+    - TAG=small
+    - TAG=medium
+    - TAG=large
+    - TAG=xlarge
+    - TAG=2xlarge
+    - TAG=4xlarge
+    - TAG=8xlarge
 
 script:
   - make build

--- a/2xlarge/config.mk
+++ b/2xlarge/config.mk
@@ -1,0 +1,1 @@
+export LOGSTASH_MAX_HEAP_SIZE=1g

--- a/4xlarge/config.mk
+++ b/4xlarge/config.mk
@@ -1,0 +1,1 @@
+export LOGSTASH_MAX_HEAP_SIZE=2g

--- a/8xlarge/config.mk
+++ b/8xlarge/config.mk
@@ -1,0 +1,1 @@
+export LOGSTASH_MAX_HEAP_SIZE=4g

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -69,6 +69,9 @@ ADD bin/run-gentleman-jerry.sh run-gentleman-jerry.sh
 ADD test /tmp/test
 RUN /tmp/test/run_tests.sh
 
+# Inject the environment corresponding to this container size
+ENV LOGSTASH_MAX_HEAP_SIZE <%= ENV.fetch 'LOGSTASH_MAX_HEAP_SIZE' %>
+
 # A volume containing a certificate pair named jerry.key/jerry.crt must be mounted into
 # this directory on the container.
 VOLUME ["/tmp/certs"]

--- a/bin/run-gentleman-jerry.sh
+++ b/bin/run-gentleman-jerry.sh
@@ -34,9 +34,9 @@ erb logstash.config.erb > "logstash-${LOGSTASH_VERSION}/logstash.config"
 
 # LS_HEAP_SIZE sets the jvm Xmx argument when running logstash, which restricts
 # the max heap size. We set this to 64MB below unless it's overridden by
-# GentlemanJerry's LOGSTASH_HEAP_SIZE. We should be conservative with the heap
-# the GentlemanJerry uses since we have one running per account and on shared
-# instances we may have many accounts on the same machine.
+# GentlemanJerry's LOGSTASH_MAX_HEAP_SIZE. We should be conservative with the
+# heap the GentlemanJerry uses since we have one running per Log Drain and on
+# shared instances we may have many accounts on the same machine.
 export LS_HEAP_SIZE=${LOGSTASH_MAX_HEAP_SIZE:-64M}
 
 # The current logstash-output-elasticsearch plugin floods the console logs with

--- a/large/config.mk
+++ b/large/config.mk
@@ -1,0 +1,1 @@
+export LOGSTASH_MAX_HEAP_SIZE=256m

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = master
+LATEST_TAG = small

--- a/medium/config.mk
+++ b/medium/config.mk
@@ -1,0 +1,1 @@
+export LOGSTASH_MAX_HEAP_SIZE=128m

--- a/small/config.mk
+++ b/small/config.mk
@@ -1,0 +1,1 @@
+export LOGSTASH_MAX_HEAP_SIZE=64m

--- a/xlarge/config.mk
+++ b/xlarge/config.mk
@@ -1,0 +1,1 @@
+export LOGSTASH_MAX_HEAP_SIZE=512m


### PR DESCRIPTION
I'm starting to suspect the small heap size we give Gentlemanjerry is
hurting us in terms of performance and causing Log Drains to spend a lot
of time GC'ing rather than actually processing logs;

This isn't intended as a long-term solution; the goal is to let us
experiment with different Gentlemanjerry sizes easily (simply by
changing the Gentlemanjerry tag for a given stack and restarting Log
Drains).

If it turns out this does solve some of our performance problems, we'll
probably revert to having one single image and expose this environment
variable in API / Sweetness.

Note: I'm removing the `master` tag here. We never actually used it.
It's just that we needed a tag to point `latest` at. We'll bring it back
if we end up going back to a single image.

---

cc @fancyremarker - you'll probably want to deploy the 8xlarge flavor to i-603193f3, since we have 3 Log Drains running there and a lot of unused RAM. If that solves the log delivery problems we're seeing, I'll work on adding this as a feature in Sweetness.