### PR TITLE
Add PrintGC

### DIFF
--- a/bin/run-gentleman-jerry.sh
+++ b/bin/run-gentleman-jerry.sh
@@ -45,6 +45,11 @@ export LS_HEAP_SIZE=${LOGSTASH_MAX_HEAP_SIZE:-64M}
 # custom log4j.properties configuration.
 export LS_JAVA_OPTS="-Dlog4j.configuration=file:/log4j.properties"
 
+# And finally, we configure Java to log GC work. This makes it easier to
+# identify whether Logstash is doing some meaningful work or spending all its
+# CPU time in GC.
+export LS_JAVA_OPTS="${LS_JAVA_OPTS} -XX:+PrintGC"
+
 cd "logstash-${LOGSTASH_VERSION}"
 while true; do
     # Ignore errors to ensure we stay up


### PR DESCRIPTION
We don't have much visibility into what Logstash is doing with its CPU
time, but we have good reason to suspect that in a lot of cases, we're
actually spending our time in GC and not really working on processing
logs.

Adding logging of GC time should help prove (or disprove..!) that
theory.

---

cc @fancyremarker @blakepettersson 