### PR TITLE
Reorder event message @timestamp

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -41,7 +41,7 @@ RUN apk-install git && \
     grep -v 'logstash-output-redis' "$GEMFILE" > "${GEMFILE}.tmp" && \
     mv "${GEMFILE}.tmp" "$GEMFILE" && \
     echo "gem 'logstash-output-http', :git => 'https://github.com/krallin/logstash-output-http'," \
-         ":ref => '77de2b1'" >> "$GEMFILE" && \
+         ":ref => '81af883'" >> "$GEMFILE" && \
     echo "gem 'logstash-mixin-http_client', :git => 'https://github.com/krallin/logstash-mixin-http_client'," \
          ":ref => '68fa376'" >> "$GEMFILE" && \
     echo "gem 'logstash-output-syslog', :git => 'https://github.com/aaw/logstash-output-syslog'," \


### PR DESCRIPTION
We put the @timestamp field first because Sumo Logic will use the first
timestamp it sees anywhere as the timestamp for the message.

https://community.aptible.com/t/sumologic-timestamp-parsing/237

cc @fancyremarker @UserNotFound 