### PR TITLE
Set Content-Type for ES requests

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -60,8 +60,10 @@ RUN cp "/logstash-${LOGSTASH_VERSION}/vendor/bundle/jruby/1.9/gems/"*"/vendor/ja
 
 # Now, for some reason, Logstash won't allow us to install this plugin like the others, so we do the next best thing... patch it in place!
 ADD patches/0001-Support-for-ES-5-Pipelines.patch /
+ADD patches/0002-Elasticsearch-Set-Content-Type.patch /
 RUN apk-install patch \
  && patch -p 1 -d "/logstash-${LOGSTASH_VERSION}/vendor/bundle/jruby/1.9/gems/logstash-output-elasticsearch-0.2.8-java" < /0001-Support-for-ES-5-Pipelines.patch \
+ && patch -p 1 -d "/logstash-${LOGSTASH_VERSION}/vendor/bundle/jruby/1.9/gems/logstash-output-elasticsearch-0.2.8-java" < /0002-Elasticsearch-Set-Content-Type.patch \
  && apk del patch
 
 ADD templates/stunnel.conf /stunnel.conf

--- a/patches/0001-Support-for-ES-5-Pipelines.patch
+++ b/patches/0001-Support-for-ES-5-Pipelines.patch
@@ -1,7 +1,7 @@
-From 4376b1e60ca3f34eb462e4f656d56df74c1f174c Mon Sep 17 00:00:00 2001
+From c27d9bca61934971e02bbc4f7dda13bb1f023176 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
-Date: Thu, 2 Feb 2017 18:49:28 +0100
-Subject: [PATCH] Support for ES 5 Pipelines
+Date: Tue, 27 Feb 2018 12:29:21 +0100
+Subject: [PATCH 1/2] Support for ES 5 Pipelines
 
 ---
  lib/logstash/outputs/elasticsearch.rb          |  5 ++++-
@@ -63,5 +63,5 @@ index 8d5026e..3c982a3 100644
  
          if options[:user] && options[:password] then
 -- 
-2.9.0
+2.14.1
 

--- a/patches/0002-Elasticsearch-Set-Content-Type.patch
+++ b/patches/0002-Elasticsearch-Set-Content-Type.patch
@@ -1,0 +1,36 @@
+From 7eaf65d5e1c1872afb006a0f706ab24fe12049b2 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 27 Feb 2018 12:25:59 +0100
+Subject: [PATCH 2/2] Elasticsearch: Set Content-Type
+
+Content-Type is required starting with Elasticsearch 6. The better
+solution here would be for us to update to a newer Logstash... but on
+the other hand, we want to move off of Logstash altogether, so this is
+not worth doing right now.
+---
+ lib/logstash/outputs/elasticsearch/protocol.rb | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/lib/logstash/outputs/elasticsearch/protocol.rb b/lib/logstash/outputs/elasticsearch/protocol.rb
+index 3c982a3..d7a1e73 100644
+--- a/lib/logstash/outputs/elasticsearch/protocol.rb
++++ b/lib/logstash/outputs/elasticsearch/protocol.rb
+@@ -81,12 +81,13 @@ module LogStash::Outputs::Elasticsearch
+             :request_timeout => 0  # and requests
+           },
+           :transport_class => transport_class,
+-          :pipeline => options[:pipeline]
++          :pipeline => options[:pipeline],
++          :headers => { 'Content-Type' => 'application/json' }
+         }
+ 
+         if options[:user] && options[:password] then
+           token = Base64.strict_encode64(options[:user] + ":" + options[:password])
+-          client_options[:headers] = { "Authorization" => "Basic #{token}" }
++          client_options[:headers]["Authorization"] = "Basic #{token}"
+         end
+ 
+         Elasticsearch::Client.new client_options
+-- 
+2.14.1
+


### PR DESCRIPTION
This is required by Elasticsearch from version 6 and up. Including this
as another patch here is definitely not ideal, but until we're able to
move off of Logstash, it's the least-friction approach we can use.

---

cc @fancyremarker 