### PR TITLE
Handle the json field.

### DIFF
--- a/templates/logstash.config.erb
+++ b/templates/logstash.config.erb
@@ -14,21 +14,18 @@ filter {
   grok {
     match => ["container", "(?<container_short>.{12})"]
   }
-  # This has to come before any actions on the "message" field, otherwise
-  # the log field containing offset and file path will be overwritten
-  # by the actual log message.
   mutate {
     rename => {
       "[log][offset]" => "offset"
       "[log][file][path]" => "file"
+      "[json][log]" => "log"
+      "[json][stream]" => "stream"
+      "[json][time]" => "time"
       "container_short" => "host"
     }
   }
-  json {
-    source => "message"
-  }
   mutate {
-    remove_field => ['agent', 'ecs', 'input', 'message']
+    remove_field => ['agent', 'ecs', 'input', 'message', 'json']
   }
   <%= ENV['LOGSTASH_FILTERS'] || "" %>
 }


### PR DESCRIPTION
Filebeat requires that if we do JSON manipulation on a log (which is required in order for us to truncate the log message while still ensuring that the end result is valid JSON) then the resulting field is called JSON, or we just dump everything into the top level. While dumping things into the top level results in less processing, it also removes control and by extensions introduces the risk of overwriting existing variables unintenionally. This ensures that we overwrite nothing by only moving what we care about.