### PR TITLE
Install custom LogDNA plugin

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -14,8 +14,12 @@ RUN apk add --no-cache coreutils curl bash openssl
 
 # Install the necessary plugins
 RUN apk add --no-cache --update --virtual .build-deps \
-      build-base ruby-dev \
-      && gem install fluent-plugin-logdna \
+      build-base ruby-dev git \
+      && git clone -b aptible https://github.com/almathew/fluent-plugin-logdna.git \
+      && cd fluent-plugin-logdna \
+      && gem build fluent-plugin-logdna.gemspec \
+      && gem install fluent-plugin-logdna-0.4.0.gem \
+      && cd .. \
       && gem install fluent-plugin-papertrail \
       && gem install fluent-plugin-elasticsearch \
       && gem install fluent-plugin-sumologic_output \


### PR DESCRIPTION
We need to match fields provided by our current (v2) Log Drains. Unfortunately, we can't even get close to matching out-of-the-box (or even with significant support modifications) with the native LogDNA fluentd plugin. 

This updates the fields output by the fluentd plugin to be a closer match to what out current log drains our outputting. A perfect match is impossible because LogDNA doesn't support arbitrary fields in the top level of the output. Instead I had to shove anything bonus in the 'meta' section