### PR TITLE
Use non-chunking http plugin

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -20,6 +20,11 @@ RUN apk add --no-cache --update --virtual .build-deps \
       && gem build fluent-plugin-logdna.gemspec \
       && gem install fluent-plugin-logdna-0.4.0.gem \
       && cd .. \
+      && git clone https://github.com/aptible/fluent-plugin-out-http.git \
+      && cd fluent-plugin-out-http \
+      && gem build fluent-plugin-out-http.gemspec \
+      && gem install fluent-plugin-out-http-1.3.3.gem \
+      && cd .. \
       && gem install fluent-plugin-papertrail \
       && gem install fluent-plugin-elasticsearch \
       && gem install fluent-plugin-sumologic_output \

--- a/test/gentlemanjerry.bats
+++ b/test/gentlemanjerry.bats
@@ -96,14 +96,8 @@ teardown() {
   openssl req -x509 -batch -nodes -newkey rsa:2048 -subj /CN=Example/ -keyout jerry.key -out jerry.crt
   # First, generate a valid config
   export FLUENTD_OUTPUT_CONFIG="@type http
-                                endpoint 127.0.0.1
-                                open_timeout 2
-                                <format>
-                                  @type json
-                                </format>
-                                <buffer>
-                                  flush_interval 5s
-                                </buffer>"
+                                endpoint_url 127.0.0.1
+                                serializer json"
   SSL_CERTIFICATE="$(cat jerry.crt)" SSL_KEY="$(cat jerry.key)" wait_for_gentlemanjerry
   rm jerry.key jerry.crt
 }
@@ -127,14 +121,8 @@ teardown() {
 @test "Gentleman Jerry should restart if it dies" {
   generate_certs
   export FLUENTD_OUTPUT_CONFIG="@type http
-                                endpoint 127.0.0.1
-                                open_timeout 2
-                                <format>
-                                  @type json
-                                </format>
-                                <buffer>
-                                  flush_interval 5s
-                                </buffer>"
+                                endpoint_url 127.0.0.1
+                                serializer json"
   wait_for_gentlemanjerry
   # Force an unclean shutdown to avoid GentlemanJerry exiting with 0
   pkill -KILL -f 'fluentd'


### PR DESCRIPTION
Use https://github.com/fluent-plugins-nursery/fluent-plugin-out-http instead of fluentd's built-in out_http plugin

Before using this plugin, attempting to use an `https_post` log drain with datadog resulted in HTTP 400 errors. Now we actually get data: 
![image](https://user-images.githubusercontent.com/877699/120564755-db985080-c3c8-11eb-82c2-8595462a621d.png)

Related sweetness changes: https://github.com/aptible/sweetness/pull/1275