### PR TITLE
fluentd: deal with ES retries properly

### DIFF
--- a/templates/fluent.conf.erb
+++ b/templates/fluent.conf.erb
@@ -33,6 +33,7 @@
   use_ssl true
   ssl_certificate /tmp/certs/jerry.crt
   ssl_key /tmp/certs/jerry.key
+  @label @JCLOGS
 </source>
 
 <label @FLUENT_LOG>
@@ -41,8 +42,10 @@
   </match>
 </label>
 
-<%= ENV['FLUENTD_FILTERS'] || "" %>
+<label @JCLOGS>
+  <%= ENV['FLUENTD_FILTERS'] || "" %>
 
-<match **>
-  <%= ENV['FLUENTD_OUTPUT_CONFIG'] || "" %>
-</match>
+  <match filebeat retry>
+    <%= ENV['FLUENTD_OUTPUT_CONFIG'] || "" %>
+  </match>
+</label>


### PR DESCRIPTION
As per https://github.com/uken/fluent-plugin-elasticsearch#retry_tag

> This setting allows custom routing of messages in response to bulk request failures. The default behavior is to emit failed records using the same tag that was provided. When set to a value other then nil, failed messages are emitted with the specified tag

Due to this behavior (emit failed records using same tag) we were seeing errors in fluentd because already-processed events were being re-processed and clogging up the works.

Depends on https://github.com/aptible/sweetness/pull/1286