### PR TITLE
Release the tested artifact.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+on:
+  release:
+    types:
+      - created
+jobs:
+  promote-master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Log in to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Promote Master With Release Tag
+        if: github.event_name == 'release' && github.event.action == 'created'
+        env:
+          TAG=${{ github.event.release.tag_name }}
+          REPOSITORY="aptible/gentlemanjerry-v2"
+        run: |
+          docker pull ${REPOSTIORY}:master
+          docker tag ${REPOSTIORY}:master ${REPOSTIORY}:${TAG}
+          docker tag ${REPOSTIORY}:master quay.io/${REPOSTIORY}:${TAG}
+          docker push ${REPOSTIORY}:${TAG}
+          docker push quay.io/${REPOSTIORY}:${TAG}

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - master
-  release:
-    types:
-      - created
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -41,7 +38,3 @@ jobs:
       - name: Push (Master merge)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: TAG=master make push
-
-      - name: Push (Publish release)
-        if: github.event_name == 'release' && github.event.action == 'created'
-        run: TAG=${{ github.event.release.tag_name }} make push


### PR DESCRIPTION
Rather than re-build the image from scratch (with un-pinned dependencies), we should promote (tag and push) the exact image that went through integration testing.